### PR TITLE
Read Sauce Connect tunnel identifier from sauce-credentials.ini

### DIFF
--- a/sauce-credentials.example.ini
+++ b/sauce-credentials.example.ini
@@ -1,3 +1,6 @@
 [credentials]
 username = 
 key = 
+
+[sauceconnect]
+tunnelIdentifier = 

--- a/wptrunner/browsers/sauce.py
+++ b/wptrunner/browsers/sauce.py
@@ -50,6 +50,11 @@ def read_sauce_config(config_path):
     url_parts[1] = full_netloc
     data["url"] = urlparse.urlunsplit(url_parts)
 
+    if config.has_option("sauceconnect", "tunnelIdentifier"):
+        tunnelIdentifier = config.get("sauceconnect", "tunnelIdentifier")
+        if tunnelIdentifier:
+            data["capabilities"]["tunnelIdentifier"] = tunnelIdentifier
+
     data["browser"] = config.get("browser", "name")
     data["capabilities"]["platform"] = config.get("browser", "platform")
     data["capabilities"]["version"] = config.get("browser", "version")


### PR DESCRIPTION
When running Sauce Connect on Travis CI, a tunnel identifier is specified.
This identifier should be specified by the 'tunnel-identifier' desired capability in a Selenium client.
This implementation reads `tunnelIdentifier` from sauce-credentials.ini and put it in the desired capabilities.
